### PR TITLE
Returning a component instance by the key.

### DIFF
--- a/Agatha.Castle/Container.cs
+++ b/Agatha.Castle/Container.cs
@@ -42,6 +42,11 @@ namespace Agatha.Castle
 			return windsorContainer.Resolve<TComponent>();
 		}
 
+        public TComponent Resolve<TComponent>(string key)
+        {
+            return windsorContainer.Resolve<TComponent>(key);
+        }
+
 		public object Resolve(Type componentType)
 		{
 			return windsorContainer.Resolve(componentType);

--- a/Agatha.Common/InversionOfControl/IContainer.cs
+++ b/Agatha.Common/InversionOfControl/IContainer.cs
@@ -10,6 +10,7 @@ namespace Agatha.Common.InversionOfControl
 		void RegisterInstance<TComponent>(TComponent instance);
 
 		TComponent Resolve<TComponent>();
+        TComponent Resolve<TComponent>(string key);
 		object Resolve(Type componentType);
 
 		void Release(object component);

--- a/Agatha.Ninject/Container.cs
+++ b/Agatha.Ninject/Container.cs
@@ -42,6 +42,11 @@ namespace Agatha.Ninject
 			return kernel.Get<TComponent>();
 		}
 
+        public TComponent Resolve<TComponent>(string key)
+        {
+            return kernel.Get<TComponent>(key);
+        }
+
 		public object Resolve(Type componentType)
 		{
 			return kernel.Get(componentType);

--- a/Agatha.Spring/Container.cs
+++ b/Agatha.Spring/Container.cs
@@ -45,6 +45,11 @@ namespace Agatha.Spring
             return (TComponent)Resolve(typeof(TComponent));
         }
 
+        public TComponent Resolve<TComponent>(string key)
+        {
+            return (TComponent)context.GetObject(key);
+        }
+
         public object Resolve(Type componentType)
         {
             var instance = context.GetObject(componentType.FullName);

--- a/Agatha.StructureMap/Container.cs
+++ b/Agatha.StructureMap/Container.cs
@@ -62,6 +62,11 @@ namespace Agatha.StructureMap
             return structureMapContainer.GetInstance<TComponent>();
         }
 
+        public TComponent Resolve<TComponent>(string key)
+        {
+            return structureMapContainer.GetInstance<TComponent>(key);
+        }
+
         public object Resolve(Type componentType)
         {
             return structureMapContainer.GetInstance(componentType);

--- a/Agatha.Unity/Container.cs
+++ b/Agatha.Unity/Container.cs
@@ -46,6 +46,11 @@ namespace Agatha.Unity
 			return unityContainer.Resolve<TComponent>();
 		}
 
+        public TComponent Resolve<TComponent>(string key)
+        {
+            return unityContainer.Resolve<TComponent>(key);
+        }
+
 		public object Resolve(Type componentType)
 		{
 			return unityContainer.Resolve(componentType);

--- a/Tests/InversionOfControlTests/ComponentResolvingByKey.cs
+++ b/Tests/InversionOfControlTests/ComponentResolvingByKey.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Agatha.Common.InversionOfControl;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
+using Microsoft.Practices.Unity;
+using Spring.Context.Support;
+using Spring.Objects.Factory.Config;
+using Spring.Objects.Factory.Support;
+using Tests.ConfigurationTests;
+using TestTypes;
+using Xunit;
+
+namespace Tests.InversionOfControlTests
+{
+    public abstract class ComponentResolvingByKey<TContainer> where TContainer : IContainer
+    {
+        protected ComponentResolvingByKey()
+        {
+            IoC.Container = InitializeContainer();
+        }
+
+        protected abstract IContainer InitializeContainer();
+
+        [Fact]
+        public void CanResolveRequestA()
+        {
+            Assert.Equal(typeof(RequestA), IoC.Container.Resolve<RequestA>("KeyForRequestA").GetType());
+        }
+
+        [Fact]
+        public void CanResolveRequestB()
+        {
+            Assert.Equal(typeof(RequestB), IoC.Container.Resolve<RequestB>("KeyForRequestB").GetType());
+        }
+    }
+
+    public sealed class ComponentResolvingByKeyWithCastle : ComponentResolvingByKey<Agatha.Castle.Container>
+    {
+        protected override IContainer InitializeContainer()
+        {
+            var container = new WindsorContainer();
+            container.Register(Component.For<RequestA>().Named("KeyForRequestA"));
+            container.Register(Component.For<RequestB>().Named("KeyForRequestB"));
+
+            return new Agatha.Castle.Container(container);
+        }
+    }
+
+    public sealed class ComponentResolvingByKeyWithUnity : ComponentResolvingByKey<Agatha.Unity.Container>
+    {
+        protected override IContainer InitializeContainer()
+        {
+            var container = new UnityContainer();
+            container.RegisterType<RequestA>("KeyForRequestA");
+            container.RegisterType<RequestB>("KeyForRequestB");
+
+            return new Agatha.Unity.Container(container);
+        }
+    }
+
+    public sealed class ComponentResolvingByKeyWithStructureMap : ComponentResolvingByKey<Agatha.StructureMap.Container>
+    {
+        protected override IContainer InitializeContainer()
+        {
+            var container = new StructureMap.Container();
+            container.Configure(x => x.ForConcreteType<RequestA>().Configure.Named("KeyForRequestA"));
+            container.Configure(x => x.ForConcreteType<RequestB>().Configure.Named("KeyForRequestB"));
+
+            return new Agatha.StructureMap.Container(container);
+        }
+    }
+
+    public sealed class ComponentResolvingByKeyWithSpring : ComponentResolvingByKey<Agatha.Spring.Container>
+    {
+        private GenericApplicationContext context;
+
+        protected override IContainer InitializeContainer()
+        {
+            this.context = new GenericApplicationContext();
+            RegisterByKey(typeof(RequestA), typeof(RequestA), "KeyForRequestA");
+            RegisterByKey(typeof(RequestB), typeof(RequestB), "KeyForRequestB");
+
+            return new Agatha.Spring.Container(context);
+        }
+
+        public void RegisterByKey(Type componentType, Type implementationType, String instanceKey)
+        {
+            if (this.context == null)
+            {
+                throw new InvalidOperationException("GenericApplicationContext is not initialized.");
+            }
+
+            var factory = new DefaultObjectDefinitionFactory();
+            var builder = ObjectDefinitionBuilder.RootObjectDefinition(factory, implementationType);
+            builder.SetAutowireMode(AutoWiringMode.AutoDetect);
+            this.context.RegisterObjectDefinition(instanceKey, builder.ObjectDefinition);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -51,9 +51,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=1.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\libs\castle\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.MicroKernel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\libs\castle\Castle.MicroKernel.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Windsor, Version=2.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\libs\castle\Castle.Windsor.dll</HintPath>
+    </Reference>
     <Reference Include="Common.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity, Version=2.0.414.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\libs\unity\Microsoft.Practices.Unity.dll</HintPath>
+    </Reference>
+    <Reference Include="Ninject, Version=2.0.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\libs\ninject\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="QuickGenerate">
       <HintPath>..\libs\quicknet\QuickGenerate.dll</HintPath>
@@ -65,6 +80,9 @@
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\rhino.mocks\Rhino.Mocks.dll</HintPath>
+    </Reference>
+    <Reference Include="Spring.Core, Version=1.3.0.20001, Culture=neutral, PublicKeyToken=629174307628bb22, processorArchitecture=MSIL">
+      <HintPath>..\libs\spring\Spring.Core.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=2.6.1.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -98,6 +116,7 @@
     <Compile Include="ConfigurationTests\ServiceLayerAndClientComponentResolving.cs" />
     <Compile Include="ConfigurationTests\ServiceLayerComponentResolving.cs" />
     <Compile Include="ConfigurationTests\TestTypes.cs" />
+    <Compile Include="InversionOfControlTests\ComponentResolvingByKey.cs" />
     <Compile Include="NewRequestProcessorTests\AbstractHandlerForTest.cs" />
     <Compile Include="NewRequestProcessorTests\CachingSpecs.cs" />
     <Compile Include="NewRequestProcessorTests\DescribedAction.cs" />


### PR DESCRIPTION
Added the TComponent Resolve<TComponent>(string key) method at IContainer interface in order to resolve a component instance by key.
