### PR TITLE
More robust interceptors in case of exception

### DIFF
--- a/Agatha.ServiceLayer/RequestProcessingErrorHandler.cs
+++ b/Agatha.ServiceLayer/RequestProcessingErrorHandler.cs
@@ -69,7 +69,7 @@ namespace Agatha.ServiceLayer
         private Type TryBasedOnCachedResponse(RequestProcessingContext context)
         {
             var cacheManager = IoC.Container.Resolve<ICacheManager>();
-            if(cacheManager.IsCachingEnabledFor(context.Request.GetType()))
+            if (cacheManager.IsCachingEnabledFor(context.Request.GetType()))
             {
                 var response = cacheManager.GetCachedResponseFor(context.Request);
                 if (response != null) return response.GetType();
@@ -79,14 +79,22 @@ namespace Agatha.ServiceLayer
 
         private Type TryBasedOnRequestHandler(RequestProcessingContext context)
         {
+            IRequestHandler handler = null;
             try
             {
-                var handler = (IRequestHandler)IoC.Container.Resolve(GetRequestHandlerTypeFor(context.Request));
+                handler = (IRequestHandler)IoC.Container.Resolve(GetRequestHandlerTypeFor(context.Request));
                 return handler.CreateDefaultResponse().GetType();
             }
             catch
             {
                 return null;
+            }
+            finally
+            {
+                if (handler != null)
+                {
+                    IoC.Container.Release(handler);
+                }
             }
         }
 

--- a/Agatha.ServiceLayer/RequestProcessor.cs
+++ b/Agatha.ServiceLayer/RequestProcessor.cs
@@ -140,6 +140,11 @@ namespace Agatha.ServiceLayer
 
         private void DisposeInterceptorsSafely(IList<IRequestHandlerInterceptor> interceptors)
         {
+            if (interceptors == null)
+            {
+                return;
+            }
+
             foreach (var interceptor in interceptors.Reverse())
             {
                 try

--- a/Tests/RequestProcessingErrorHandlerSpecs.cs
+++ b/Tests/RequestProcessingErrorHandlerSpecs.cs
@@ -102,7 +102,7 @@ namespace Tests
         {
             protected RequestProcessingContext Context;
             private Request request;
-            private IRequestProcessingErrorHandler errorHandler = new RequestProcessingErrorHandler();
+            private IRequestProcessingErrorHandler errorHandler;
             private ICacheManager cacheManager;
 
             protected IContainer Container
@@ -113,7 +113,7 @@ namespace Tests
             protected override void Given()
             {
                 IoC.Container = new Container();
-                errorHandler = new RequestProcessingErrorHandler();
+                errorHandler = new RequestProcessingErrorHandler(new ServiceLayerConfiguration(IoC.Container));
                 request = new RequestA();
                 Context = new RequestProcessingContext(request);
                 cacheManager = Stubbed<ICacheManager>();


### PR DESCRIPTION
Hey,

Recently I discovered in my project that when one interceptor throws in IRequestHandlerInterceptor.BeforeHandlingRequest, for all previously executed interceptors IRequestHandlerInterceptor.AfterHandlingRequest is not executed. In our project it would kill application because of some work that really need to be done after handling every request, but not when BeforeHandlingRequest was not called (so using Dispose is not clean solution).

I believe that Agatha should guarantee that for every interceptor that had BeforeHandlingRequest called, the AfterHandlingRequest  also will be. ASP.NET MVC action filters behave in such way for example. 
