### PR TITLE
Handler auto registration only by interface

### DIFF
--- a/Agatha.ServiceLayer.Silverlight/ServiceLayerConfiguration.cs
+++ b/Agatha.ServiceLayer.Silverlight/ServiceLayerConfiguration.cs
@@ -91,9 +91,9 @@ namespace Agatha.ServiceLayer
 
 		private void RegisterRequestHandlers()
 		{
-			var oneWayHandlerType = typeof(OneWayRequestHandler);
+			var oneWayHandlerType = typeof(IOneWayRequestHandler);
 			var openOneWayHandlerType = typeof(IOneWayRequestHandler<>);
-			var requestResponseHandlerType = typeof(RequestHandler);
+			var requestResponseHandlerType = typeof(IRequestHandler);
 			var openRequestReponseHandlerType = typeof(IRequestHandler<>);
 
 			Dictionary<Type, Type> requestWithRequestHandlers = new Dictionary<Type, Type>();
@@ -104,7 +104,7 @@ namespace Agatha.ServiceLayer
 					if (type.IsAbstract)
 						continue;
 
-					if (!type.IsSubclassOf(oneWayHandlerType) && !type.IsSubclassOf(requestResponseHandlerType))
+					if (!oneWayHandlerType.IsAssignableFrom(type) && !requestResponseHandlerType.IsAssignableFrom(type))
 						continue;
 
 					var requestType = GetRequestType(type);
@@ -112,11 +112,11 @@ namespace Agatha.ServiceLayer
 					if (requestType != null)
 					{
 						Type handlerType = null;
-						if (type.IsSubclassOf(oneWayHandlerType))
+						if (oneWayHandlerType.IsAssignableFrom(type))
 						{
 							handlerType = openOneWayHandlerType.MakeGenericType(requestType);
 						}
-						else if (type.IsSubclassOf(requestResponseHandlerType))
+						else if (requestResponseHandlerType.IsAssignableFrom(type))
 						{
 							handlerType = openRequestReponseHandlerType.MakeGenericType(requestType);
 						}

--- a/Agatha.ServiceLayer/ServiceLayerConfiguration.cs
+++ b/Agatha.ServiceLayer/ServiceLayerConfiguration.cs
@@ -129,9 +129,9 @@ namespace Agatha.ServiceLayer
 
         private void RegisterRequestHandlers()
         {
-            var oneWayHandlerType = typeof(OneWayRequestHandler);
+            var oneWayHandlerType = typeof(IOneWayRequestHandler);
             var openOneWayHandlerType = typeof(IOneWayRequestHandler<>);
-            var requestResponseHandlerType = typeof(RequestHandler);
+            var requestResponseHandlerType = typeof(IRequestHandler);
             var openRequestReponseHandlerType = typeof(IRequestHandler<>);
 
             var requestWithRequestHandlers = new Dictionary<Type, Type>();
@@ -142,7 +142,7 @@ namespace Agatha.ServiceLayer
                     if (type.IsAbstract)
                         continue;
 
-                    if (!type.IsSubclassOf(oneWayHandlerType) && !type.IsSubclassOf(requestResponseHandlerType))
+                    if (!oneWayHandlerType.IsAssignableFrom(type) && !requestResponseHandlerType.IsAssignableFrom(type))
                         continue;
 
                     RequestHandlerRegistry.Register(type);
@@ -152,11 +152,11 @@ namespace Agatha.ServiceLayer
                     if (requestType != null)
                     {
                         Type handlerType = null;
-                        if (type.IsSubclassOf(oneWayHandlerType))
+                        if (oneWayHandlerType.IsAssignableFrom(type))
                         {
                             handlerType = openOneWayHandlerType.MakeGenericType(requestType);
                         }
-                        else if (type.IsSubclassOf(requestResponseHandlerType))
+                        else if (requestResponseHandlerType.IsAssignableFrom(type))
                         {
                             handlerType = openRequestReponseHandlerType.MakeGenericType(requestType);
                         }


### PR DESCRIPTION
By implementing some services I noticed that my handlers are not registered. 
Looked at the code and found that implemented handlers requires to be derived from OneWayRequestHandler or from RequestHandler.
However, I think that's why interfaces are implemented and handlers implementint IOneWayRequestHandler or IRequestHandler should be registered too.
